### PR TITLE
feat(cassandra): Use consistenly level ONE in ingestion pipeline

### DIFF
--- a/cassandra/src/main/scala/filodb.cassandra/metastore/CheckpointTable.scala
+++ b/cassandra/src/main/scala/filodb.cassandra/metastore/CheckpointTable.scala
@@ -36,7 +36,7 @@ sealed class CheckpointTable(val config: Config,
       s"""SELECT groupnum, offset FROM $tableString WHERE
          | databasename = ? AND
          | datasetname = ? AND
-         | shardnum = ? """.stripMargin).setConsistencyLevel(ConsistencyLevel.QUORUM)
+         | shardnum = ? """.stripMargin).setConsistencyLevel(ConsistencyLevel.ONE)
     // we want consistent reads during recovery
 
   lazy val writeCheckpointCql = {


### PR DESCRIPTION
**Pull Request checklist**

- [X] The commit(s) message(s) follows the contribution [guidelines](CONTRIBUTING.md) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?

Following is supposed to be taken care after this [commit](https://github.com/filodb/FiloDB/commit/ac016af1220403401f095b9fda81e7fcf1df0f46):
`* Currently retaining default QUORUM consistency for ingestion writes, but will change to ONE in subsequent PR.`

Fixing the same now.